### PR TITLE
Convert .pdf to *.pdf in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 # *.pdf
 
 ## Generated if empty string is given at "Please type another file name for output:"
-.pdf
+*.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl


### PR DESCRIPTION
This prevents the generated pdf file to be included in the repository. This is to prevent outdated pdf files to be present alongside the tex files.